### PR TITLE
fix: input order

### DIFF
--- a/middleman.js
+++ b/middleman.js
@@ -441,7 +441,7 @@ const render = (content, options = {}) => {
           current = match;
           console.log();
           console.log(await prettier.format(distilled, { parser: 'html', printWidth: 120 }));
-          await autofill(page, distilled, ['email', 'password', 'tel', 'text']);
+          await autofill(page, distilled, ['email', 'tel', 'text', 'password']);
           await autoclick(page, distilled);
           if (await terminate(page, distilled)) {
             break;


### PR DESCRIPTION
Ordering input so user will enter identifier first, then password.

Before:
<img width="940" height="355" alt="Screenshot 2025-09-05 at 16 26 31" src="https://github.com/user-attachments/assets/88b281df-3463-4759-871a-7092a6cebd80" />


After:
<img width="1211" height="310" alt="Screenshot 2025-09-05 at 16 26 52" src="https://github.com/user-attachments/assets/e74d0765-0cb6-4452-afd8-aab081377c3d" />
