### PR TITLE
Convert the distilled HTML into JSON, when the conversion is defined

### DIFF
--- a/specs/goodreads/goodreads-books.html
+++ b/specs/goodreads/goodreads-books.html
@@ -6,5 +6,17 @@
     <table>
       <tbody gg-stop gg-match-html="tbody#booksBody"></tbody>
     </table>
+    <script type="application/json" id="bookshelf">
+      {
+        "rows": "tr.review",
+        "columns": [
+          { "name": "title", "selector": "td.title > div > a", "attribute": "title" },
+          { "name": "author", "selector": "td.author > div > a" },
+          { "name": "rating", "selector": "td.avg_rating > div" },
+          { "name": "url", "selector": "td.cover a", "attribute": "href" },
+          { "name": "cover", "selector": "td.cover img", "attribute": "src" }
+        ]
+      }
+    </script>
   </body>
 </html>

--- a/specs/nytimes/nytimes-best-sellers.html
+++ b/specs/nytimes/nytimes-best-sellers.html
@@ -3,30 +3,16 @@
     <title>NYTimes Best Sellers</title>
   </head>
   <body>
-    <style>
-      ol img {
-        max-width: 120px;
-      }
-      ol p {
-        color: black;
-      }
-      ol footer {
-        border: none;
-        background-color: transparent;
-      }
-
-      ol button,
-      p:not([itemprop]):first-of-type,
-      p[itemprop='publisher'] {
-        display: none;
-      }
-      a {
-        text-decoration: none;
-      }
-      p[itemprop='description'] {
-        font-style: italic;
-      }
-    </style>
     <ol gg-stop gg-match-html="section[data-testid=section-combined-print-and-e-book-fiction] ol"></ol>
+    <script type="application/json" id="bookshelf">
+      {
+        "rows": "li",
+        "columns": [
+          { "name": "title", "selector": "h3" },
+          { "name": "author", "selector": "p[itemprop=author]" },
+          { "name": "description", "selector": "p[itemprop=description]" }
+        ]
+      }
+    </script>
   </body>
 </html>

--- a/specs/slashdot/slashdot-most-discussed.html
+++ b/specs/slashdot/slashdot-most-discussed.html
@@ -4,5 +4,15 @@
   </head>
   <body>
     <section gg-stop gg-match-html="section#mostdiscussed-content"></section>
+    <script type="application/json" id="most-discussed">
+      {
+        "rows": "li",
+        "columns": [
+          { "name": "title", "selector": "a" },
+          { "name": "link", "selector": "a", "attribute": "href" },
+          { "name": "count", "selector": "span.cmntcnt" }
+        ]
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This is only supported in the JavaScript version for now. To give it a try, launch as usual with `./middleman.js` and then open `localhost:3000`. Pick either the example for NYTimes Best-sellers, Slashdot discussion, or Goodreads (other examples do not have any conversion defined yet). Expect to see data in JSON as the very final step.

To check on the CLI, run something like:

```bash
./middleman.js distill https://www.nytimes.com/books/best-sellers/
```

which should print out the best-sellers list in pretty JSON.

The conversion itself is defined by specifying the selector for iterating the row, and for each column/field. This is very similar with the so-calling locator parsing in MCP GetGather.

<img width="800" alt="2025-09-07 middleman nytimes bestsellers json" src="https://github.com/user-attachments/assets/19b9bf65-9ae1-4d76-9bc0-e6cef980407b" />

<img width="800" alt="2025-09-07 middleman goodreads json" src="https://github.com/user-attachments/assets/37e2f070-8336-41d3-9067-8fdc99a74e39" />
