### PR TITLE
JSONify the CFB schedule

### DIFF
--- a/specs/espn/cfb-schedule.html
+++ b/specs/espn/cfb-schedule.html
@@ -1,8 +1,7 @@
 <html gg-domain="espn">
-
-<body>
-  <section gg-stop gg-match-html="section:has(.Table)"></section>
-  <script type="application/json" id="cfb-schedule">
+  <body>
+    <section gg-stop gg-match-html="section:has(.Table)"></section>
+    <script type="application/json" id="cfb-schedule">
       {
         "rows": ".Table tbody tr",
         "columns": [
@@ -17,6 +16,5 @@
         ]
       }
     </script>
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION
Adds rows and columns to the schedule html to put the matchups into a JSON structure based on new code in the middleman.js/py files for extracting relevant data from the HTML into readable format.

<img width="950" height="499" alt="Screenshot 2025-09-08 at 2 26 31 PM" src="https://github.com/user-attachments/assets/bf705242-983e-4f9e-bc10-ed2437b074de" />
