### PR TITLE
fix: handle autoclick without input on web ui

### DIFF
--- a/middleman.js
+++ b/middleman.js
@@ -776,7 +776,10 @@ const render = (content, options = {}) => {
       const title = document.title;
       const action = `/link/${id}`;
 
-      if (names.length > 0 && inputs.length === names.length) {
+      if (
+        (names.length > 0 && inputs.length === names.length) ||
+        (document.querySelector('[gg-autoclick]') && inputs.length === 0 && names.length === 0)
+      ) {
         await autoclick(page, distilled);
         if (await terminate(page, distilled)) {
           console.log(`${GREEN}${CHECK} Finished!${NORMAL}`);

--- a/middleman.py
+++ b/middleman.py
@@ -640,7 +640,9 @@ async def link(id: str, request: Request):
         title = title_element.get_text() if title_element else "MIDDLEMAN"
         action = f"/link/{id}"
 
-        if len(names) > 0 and len(inputs) == len(names):
+        if (len(names) > 0 and len(inputs) == len(names)) or (
+            document.find(attrs={"gg-autoclick": True}) and len(inputs) == 0 and len(names) == 0
+        ):
             await autoclick(page, distilled)
             if await terminate(page, distilled):
                 print(f"{GREEN}{CHECK} Finished!{NORMAL}")


### PR DESCRIPTION
There’s a pattern that only clicks certain elements (without any input), but it won’t work because `autoclick` is inside a condition that requires `inputs > 0`. Adding another condition of `autoclick if it exists and there are no inputs` should fix this issue.

To test this run `middleman.js` / `middleman.py`. Then open: `localhost:3000/start?location=goodreads.com/signin`

Before fix:

https://github.com/user-attachments/assets/6c8bf2c0-91ff-4d2a-8886-075ad4b36477




After fix:

https://github.com/user-attachments/assets/7594e27e-0473-400f-93c2-8f3de45446a7

