### PR TITLE
feat: handle button choice

### DIFF
--- a/middleman.js
+++ b/middleman.js
@@ -635,7 +635,8 @@ const render = (content, options = {}) => {
       { title: 'Gofood Order History', link: '/start?location=gofood.co.id/en/orders' },
       { title: 'Agoda Booking History', link: '/start?location=agoda.com/account/bookings.html' },
       { title: 'ESPN College Football Schedule', link: '/start?location=espn.com/college-football/schedule' },
-      { title: 'NBA Key Dates', link: '/start?location=nba.com/news/key-dates' }
+      { title: 'NBA Key Dates', link: '/start?location=nba.com/news/key-dates' },
+      { title: 'Shopee Login', link: '/start?location=shopee.co.id/buyer/login' }
     ];
 
     const itemize = ({ title, link }) => `<li><a href="${link}" target="_blank">${title}</a></li>`;
@@ -792,6 +793,16 @@ const render = (content, options = {}) => {
 
         console.log(`${GREEN}${CHECK} All form fields are filled${NORMAL}`);
         continue;
+      }
+
+      if (fields.button) {
+        const button = document.querySelector(`button[value="${fields.button}"]`);
+        if (button && !button.getAttribute('gg-autoclick')) {
+          const { selector, frame_selector } = get_selector(button.getAttribute('gg-match'));
+          console.log(`${CYAN}${ARROW} Clicking button ${BOLD}${selector}${NORMAL}`);
+          await click(page, selector, 3 * 1000, frame_selector);
+          continue;
+        }
       }
 
       if (await terminate(page, distilled)) {

--- a/middleman.py
+++ b/middleman.py
@@ -499,6 +499,7 @@ async def home():
         {"title": "Agoda Booking History", "link": "/start?location=agoda.com/account/bookings.html"},
         {"title": "ESPN College Football Schedule", "link": "/start?location=espn.com/college-football/schedule"},
         {"title": "NBA Key Dates", "link": "/start?location=nba.com/news/key-dates"},
+        {"title": "Shopee Login", "link": "/start?location=shopee.co.id/buyer/login"},
     ]
 
     items = [f'<li><a href="{item["link"]}" target="_blank">{item["title"]}</a></li>' for item in examples]
@@ -653,6 +654,14 @@ async def link(id: str, request: Request):
 
             print(f"{GREEN}{CHECK} All form fields are filled{NORMAL}")
             continue
+
+        if fields.get("button"):
+            button = document.find("button", {"value": fields.get("button")})
+            if button and not button.get("gg-autoclick"):
+                button_selector, button_frame_selector = get_selector(str(button.get("gg-match")))
+                print(f"{CYAN}{ARROW} Clicking button {BOLD}{button_selector}{NORMAL}")
+                await click(page, str(button_selector), frame_selector=button_frame_selector)
+                continue
 
         if await terminate(page, distilled):
             print(f"{GREEN}{CHECK} Finished!{NORMAL}")

--- a/specs/shopee/shopee-home.html
+++ b/specs/shopee/shopee-home.html
@@ -1,0 +1,5 @@
+<html gg-domain="shopee" gg-priority="2">
+  <body>
+    <button gg-autoclick gg-match="div.navbar__username"></button>
+  </body>
+</html>

--- a/specs/shopee/shopee-login.html
+++ b/specs/shopee/shopee-login.html
@@ -1,0 +1,7 @@
+<html gg-domain="shopee">
+  <body>
+    <input type="text" name="loginKey" gg-match="input[name=loginKey]" placeholder="No. Handphone/Username/Email" />
+    <input type="password" name="password" gg-match="input[name=password]" placeholder="Password" />
+    <button gg-autoclick gg-match="button:has-text('LOG IN')">LOG IN</button>
+  </body>
+</html>

--- a/specs/shopee/shopee-purchase.html
+++ b/specs/shopee/shopee-purchase.html
@@ -1,0 +1,19 @@
+<html gg-domain="shopee">
+  <body>
+    <div gg-stop gg-match-html="main[aria-role='tabpanel']:has-text('chat') > div"></div>
+    <script type="application/json" id="purchase">
+      {
+        "rows": "div.YL_VlX",
+        "columns": [
+          { "name": "store_name", "selector": "div[tabindex='0']:not(:has(svg))" },
+          { "name": "product_name", "selector": "span[tabindex='0']" },
+          { "name": "product_image", "selector": "img", "attribute": "src" },
+          {
+            "name": "total_price",
+            "selector": "div[aria-label*='Total Pesanan']"
+          }
+        ]
+      }
+    </script>
+  </body>
+</html>

--- a/specs/shopee/shopee-verification-link-selection.html
+++ b/specs/shopee/shopee-verification-link-selection.html
@@ -1,0 +1,17 @@
+<html gg-domain="shopee">
+  <body>
+    <h3 gg-match="aside > div > div > div">
+      Kamu akan menerima link verifikasi WhatsApp yang dikirim ke nomor telepon terdaftar.
+    </h3>
+    <button
+      name="button"
+      value="whatsapp"
+      gg-match="button[aria-label='Click the button to send the authentication link through WhatsAPP']"
+    ></button>
+    <button
+      name="button"
+      value="sms"
+      gg-match="button[aria-label='Click the button to send the authentication link through SMS if you cannot receive WhatsAPP messages']"
+    ></button>
+  </body>
+</html>

--- a/specs/shopee/shopee-verification-link.html
+++ b/specs/shopee/shopee-verification-link.html
@@ -1,0 +1,6 @@
+<html gg-domain="shopee">
+  <body>
+    <h2 gg-match="h2">Untuk keamanan akun, mohon verifikasi identitas kamu dengan salah satu cara di bawah ini.</h2>
+    <button name="button" value="link" gg-match="button[aria-label='Verifikasi melalui link']"></button>
+  </body>
+</html>


### PR DESCRIPTION
Related to this issue: #24 

Currently, the only button we have is the one that submits the form input (with gg-autoclick). There’s no way to create a button that `click` a specific selector. This PR introduces the ability to have a button that `click` a specific selector.

The idea is to assign a value to the button. This value will be sent with the form data and can be used to identify which button was clicked, allowing us to retrieve the button’s selector.

To test this run `middleman.js` / `middleman.py`. Then open: `localhost:3000/start?location=shopee.co.id/buyer/login`

Here's the demo video:

https://github.com/user-attachments/assets/df177d0d-f459-4c65-849a-023161f32939

