### PR TITLE
Properly handle checkboxes

### DIFF
--- a/middleman.js
+++ b/middleman.js
@@ -724,8 +724,21 @@ const render = (content, options = {}) => {
         const name = input.name;
         if (selector) {
           if (input.type === 'checkbox') {
-            names.push(name || 'checkbox');
-            console.log(`${CYAN}${ARROW} Handling ${NORMAL}${selector} using autoclick`);
+            if (!name) {
+              console.warn(`${CROSS}${RED} No name for the checkbox ${NORMAL}${selector}`);
+              continue;
+            }
+            const value = fields[name];
+            const checked = value && value.length > 0;
+            names.push(name);
+            console.log(`${CYAN}${ARROW} Status of checkbox ${BOLD}${name}=${checked}${NORMAL}`);
+            if (checked) {
+              if (frame_selector) {
+                await page.frameLocator(frame_selector).locator(selector).check();
+              } else {
+                await page.check(selector);
+              }
+            }
           } else if (input.type === 'radio') {
             const value = fields[name];
             if (!value || value.length === 0) {

--- a/middleman.js
+++ b/middleman.js
@@ -346,6 +346,16 @@ const autofill = async (page, distilled) => {
       } else {
         await page.check(selector);
       }
+    } else if (type === 'checkbox') {
+      const checked = element.getAttribute('checked');
+      if (checked !== null) {
+        console.log(`${CYAN}${ARROW} Checking ${BOLD}${name}${NORMAL}`);
+        if (frame_selector) {
+          await page.frameLocator(frame_selector).locator(selector).check();
+        } else {
+          await page.check(selector);
+        }
+      }
     }
   }
 

--- a/middleman.py
+++ b/middleman.py
@@ -598,8 +598,18 @@ async def link(id: str, request: Request):
 
                 if selector:
                     if input.get("type") == "checkbox":
-                        names.append(str(name) if name else "checkbox")
-                        print(f"{CYAN}{ARROW} Handling {NORMAL}{selector} using autoclick")
+                        if not name:
+                            print(f"{CROSS}{RED} No name for the checkbox {NORMAL}{selector}")
+                            continue
+                        value = fields.get(str(name))
+                        checked = value and len(str(value)) > 0
+                        names.append(str(name))
+                        print(f"{CYAN}{ARROW} Status of checkbox {BOLD}{name}={checked}{NORMAL}")
+                        if checked:
+                            if frame_selector:
+                                await page.frame_locator(str(frame_selector)).locator(str(selector)).check()
+                            else:
+                                await page.check(str(selector))
                     elif input.get("type") == "radio":
                         value = fields.get(str(name)) if name else None
                         if not value or len(str(value)) == 0:

--- a/middleman.py
+++ b/middleman.py
@@ -336,6 +336,14 @@ async def autofill(page: Page, distilled: str):
                     await page.frame_locator(str(frame_selector)).locator(str(selector)).check()
                 else:
                     await page.check(str(selector))
+        elif input_type == "checkbox":
+            checked = element.get("checked")
+            if checked is not None:
+                print(f"{CYAN}{ARROW} Checking {BOLD}{name}{NORMAL}")
+                if frame_selector:
+                    await page.frame_locator(str(frame_selector)).locator(str(selector)).check()
+                else:
+                    await page.check(str(selector))
 
     return str(document)
 

--- a/specs/acme/acme-signin.html
+++ b/specs/acme/acme-signin.html
@@ -1,0 +1,10 @@
+<html gg-priority="-100">
+  <body>
+    <h3 gg-optional gg-match="h1">Sign In</h3>
+    <p gg-optional gg-match="div.feedback-message"></p>
+    <input autofocus name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
+    <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
+    <input name="remember" type="checkbox" checked gg-match="input[type=checkbox]" style="display: none" />
+    <button gg-autoclick gg-match="button[type=submit]">Sign In</button>
+  </body>
+</html>

--- a/specs/acme/acme-success.html
+++ b/specs/acme/acme-success.html
@@ -1,0 +1,6 @@
+<html gg-priority="-100">
+  <body>
+    <h3 gg-match="h1:has-text('success')">Success</h3>
+    <p gg-stop gg-match=".feedback-message"></p>
+  </body>
+</html>

--- a/specs/goodreads/goodreads-signin.html
+++ b/specs/goodreads/goodreads-signin.html
@@ -7,7 +7,7 @@
     <p gg-optional gg-match=".a-alert-content"></p>
     <input autofocus name="email" type="email" placeholder="Email" gg-match="input[type=email]" />
     <input name="password" type="password" placeholder="Password" gg-match="input[type=password]" />
-    <input gg-autoclick name="remember" type="checkbox" gg-match="input[name=rememberMe]" style="display: none" />
+    <input name="remember" type="checkbox" checked gg-match="input[name=rememberMe]" style="display: none" />
     <button gg-autoclick gg-match="input[type=submit]">Sign in</button>
   </body>
 </html>


### PR DESCRIPTION
Typically, a checkbox is used to denote "Remember me", to persist the login session. Rather than using the autoclick hack, this change handles it by properly relaying the checked status from the distilled page to the actual web page.

Verifying is tricky. The best way is to run the ACME test server from the MCP GetGather project and make sure it's running on localhost:5001.

Then run `./middleman.js` or `./middleman.py` as usual, and open this in the browser:

http://localhost:3000/start?location=http://localhost:5001/auth/email-and-password-checkbox

This will initiate the distillation loop on the ACME test page which contains the email and password and also the "Remember me" checkbox. The checkbox on that ACME test page will be checked, as the automation progresses.

<img width="2552" height="1383" alt="2025-10-05 middleman checkbox" src="https://github.com/user-attachments/assets/58c84c5f-da31-4b8c-ac76-6108419a4aaf" />
