### PR TITLE
Prioritize checking for termination in the distillation loop

### DIFF
--- a/middleman.js
+++ b/middleman.js
@@ -586,13 +586,12 @@ const render = (content, options = {}) => {
         if (match.distilled === current.distilled) {
           console.log('Still the same:', match.name);
         } else {
-          const distilled = await autofill(page, match.distilled);
+          let distilled = match.distilled;
           current.name = match.name;
           current.distilled = distilled;
           console.log();
           console.log(await prettier.format(distilled, { parser: 'html', printWidth: 120 }));
 
-          await autoclick(page, distilled);
           if (await terminate(page, distilled)) {
             const converted = await convert(page, distilled);
             if (converted) {
@@ -601,6 +600,9 @@ const render = (content, options = {}) => {
             }
             break;
           }
+
+          distilled = await autofill(page, match.distilled);
+          await autoclick(page, distilled);
         }
       } else {
         console.warn(`${CROSS}${RED} No matched pattern found${NORMAL}`);
@@ -726,8 +728,23 @@ const render = (content, options = {}) => {
       console.log();
       console.log(await prettier.format(current.distilled, { parser: 'html', printWidth: 120 }));
 
-      const names = [];
       const document = parse(distilled);
+      const title = document.title;
+      const action = `/link/${id}`;
+
+      if (await terminate(page, distilled)) {
+        console.log(`${GREEN}${CHECK} Finished!${NORMAL}`);
+        const converted = await convert(page, distilled);
+        await context.close();
+        if (converted) {
+          console.log();
+          console.log(converted);
+          return c.json(converted);
+        }
+        return c.html(render(document.body.innerHTML, { title, action }));
+      }
+
+      const names = [];
       const inputs = document.querySelectorAll('input');
       for (const input of inputs) {
         const { selector, frame_selector } = get_selector(input.getAttribute('gg-match'));
@@ -794,40 +811,13 @@ const render = (content, options = {}) => {
         }
       }
 
-      console.log(await prettier.format(current.distilled, { parser: 'html', printWidth: 120 }));
-
-      const title = document.title;
-      const action = `/link/${id}`;
-
       if (names.length > 0 && inputs.length === names.length) {
         await autoclick(page, distilled);
-        if (await terminate(page, distilled)) {
-          console.log(`${GREEN}${CHECK} Finished!${NORMAL}`);
-          const converted = await convert(page, distilled);
-          await context.close();
-          if (converted) {
-            console.log();
-            console.log(converted);
-            return c.json(converted);
-          }
-          return c.html(render(document.body.innerHTML, { title, action }));
-        }
-
         console.log(`${GREEN}${CHECK} All form fields are filled${NORMAL}`);
         continue;
       }
 
-      if (await terminate(page, distilled)) {
-        console.log(`${GREEN}${CHECK} Finished!${NORMAL}`);
-        const converted = await convert(page, distilled);
-        await context.close();
-        if (converted) {
-          return c.json(converted);
-        }
-      } else {
-        console.warn(`${CROSS}${RED} Not all form fields are filled${NORMAL}`);
-      }
-
+      console.warn(`${CROSS}${RED} Not all form fields are filled${NORMAL}`);
       return c.html(render(document.body.innerHTML, { title, action }));
     }
 


### PR DESCRIPTION
This is to prepare for the separation of autoclick and form submission.

To simplify the logic, the first step in the distillation loop should be checking for a possible termination (gg-stop). As a bonus, this will give some extra time for the upstream website to process any form submission (carried out typically as the last step in the loop).

To verify, run in the CLI as usual, e.g.

```bash
./middleman.py run bbc.com/saved
```

Also, run the web UI with `./middleman.py` and opening `localhost:3000`. Then verify with NY Times Best-sellers, NBA key dates, etc etc.