### PR TITLE
Add a safeguard against null element during JSON conversion

### DIFF
--- a/middleman.js
+++ b/middleman.js
@@ -395,7 +395,7 @@ const extractValue = (item, attribute = null) => {
     return typeof value === 'string' ? value.trim() : '';
   }
 
-  return item.textContent.trim();
+  return item?.textContent.trim();
 };
 
 const convert = async (page, distilled) => {
@@ -420,7 +420,9 @@ const convert = async (page, distilled) => {
             kv[name] = Array.from(items).map((item) => extractValue(item, attribute));
           } else {
             const item = el.querySelector(selector);
-            kv[name] = extractValue(item, attribute);
+            if (item) {
+              kv[name] = extractValue(item, attribute);
+            }
           }
         });
         if (Object.keys(kv).length > 0) {


### PR DESCRIPTION
This is applying the same safeguard which is already in the Python code, to the JavaScript version.

To verify, run the distillation loop for NY Times Best-sellers:

```bash
./middleman.js run www.nytimes.com/books/best-sellers
```

Before this change, the conversion from HTML to JSON will fail.

With this change, the final JSON result is obtained without any issue.