### PR TITLE
Tweak the separation between autoclick and form submission

### DIFF
--- a/specs/goodreads/goodreads-modal.html
+++ b/specs/goodreads/goodreads-modal.html
@@ -1,0 +1,8 @@
+<html gg-domain="goodreads">
+  <body>
+    <p gg-match=".appleConnectButton">Apple</p>
+    <p gg-match=".amazonConnectButton">Amazon</p>
+    <p gg-match="a:has-text('Sign up')">Sign up</p>
+    <p gg-autoclick gg-match=".signInOption a">Email sign-in</p>
+  </body>
+</html>

--- a/specs/goodreads/goodreads-overlay.html
+++ b/specs/goodreads/goodreads-overlay.html
@@ -1,6 +1,6 @@
 <html gg-domain="goodreads" gg-priority="0">
   <body>
     <h1>Discover</h1>
-    <button gg-autoclick gg-match='div.loginModal a:has-text("Sign in")'>Sign-in</button>
+    <p gg-autoclick gg-match='div.loginModal a:has-text("Sign in")'>Sign-in</p>
   </body>
 </html>

--- a/specs/goodreads/goodreads-select-signin.html
+++ b/specs/goodreads/goodreads-select-signin.html
@@ -1,8 +1,7 @@
-<html gg-domain="goodreads">
+<html gg-domain="goodreads" gg-priority="1">
   <body>
-    <button gg-match=".thirdPartyConnectButton">Third Party</button>
-    <button gg-match=".appleConnectButton">Apple</button>
-    <button gg-match=".amazonSignInButton">Amazon</button>
-    <button gg-autoclick gg-match="button.authPortalSignInButton">Email sign-in</button>
+    <p gg-match=".amazonConnectButton">Amazon</p>
+    <p gg-optional gg-match=".appleConnectButton">Apple</p>
+    <p gg-autoclick gg-match="button.authPortalConnectButton">Sign in with email</p>
   </body>
 </html>

--- a/specs/goodreads/goodreads-signup.html
+++ b/specs/goodreads/goodreads-signup.html
@@ -1,6 +1,0 @@
-<html gg-domain="goodreads" gg-priority="4">
-  <body>
-    <h1 gg-match='h1:has-text("Sign up")'>Sign up</h1>
-    <button gg-autoclick gg-match="a[href*=sign_in]">Sign in</button>
-  </body>
-</html>


### PR DESCRIPTION
This is just a minor tweak to PR #38, with the goal of making it semantically more explicit that there are two distinctive steps:

* clicking on any elements with gg-autoclick attribute
* submitting the form

The second step is only carried out when all the form fields are properly filled.

To verify, just launch and test the usual examples (Goodreads, Amazon, NYTimes Best-sellers, NBA key dates, etc).