### PR TITLE
improvement 2: increase distill speed by batching actions (click & fill)

### DIFF
--- a/middleman.py
+++ b/middleman.py
@@ -1064,8 +1064,6 @@ async def link(id: str, request: Request):
                 return JSONResponse(converted)
             return HTMLResponse(render(str(document.find("body")), {"title": title, "action": action}))
 
-
-
         if fields.get("button"):
             button = document.find("button", value=str(fields.get("button")))
             if button and isinstance(button, Tag):
@@ -1102,13 +1100,11 @@ async def link(id: str, request: Request):
                         names.append(str(name))
                         print(f"{CYAN}{ARROW} Status of checkbox {BOLD}{name}={checked}{NORMAL}")
                         if checked:
-                            pending_actions.append(
-                                {
-                                    "key": f"checkbox:{name}:{len(pending_actions)}",
-                                    "kind": "click",
-                                    "selector": str(selector),
-                                }
-                            )
+                            pending_actions.append({
+                                "key": f"checkbox:{name}:{len(pending_actions)}",
+                                "kind": "click",
+                                "selector": str(selector),
+                            })
                     elif input.get("type") == "radio":
                         value = fields.get(str(name)) if name else None
                         if not value or len(str(value)) == 0:
@@ -1121,13 +1117,11 @@ async def link(id: str, request: Request):
                         print(f"{CYAN}{ARROW} Handling radio button group {BOLD}{name}{NORMAL}")
                         print(f"{CYAN}{ARROW} Using form data {BOLD}{name}={value}{NORMAL}")
                         radio_selector, _ = get_selector(str(radio.get("gg-match")))
-                        pending_actions.append(
-                            {
-                                "key": f"radio:{value}:{len(pending_actions)}",
-                                "kind": "click",
-                                "selector": str(radio_selector),
-                            }
-                        )
+                        pending_actions.append({
+                            "key": f"radio:{value}:{len(pending_actions)}",
+                            "kind": "click",
+                            "selector": str(radio_selector),
+                        })
                         radio["checked"] = "checked"
                         current["distilled"] = str(document)
                         names.append(str(input.get("id")) if input.get("id") else "radio")
@@ -1138,14 +1132,12 @@ async def link(id: str, request: Request):
                             names.append(str(name))
                             input["value"] = str(value)
                             current["distilled"] = str(document)
-                            pending_actions.append(
-                                {
-                                    "key": f"set:{name}:{len(pending_actions)}",
-                                    "kind": "set_value",
-                                    "selector": str(selector),
-                                    "value": str(value),
-                                }
-                            )
+                            pending_actions.append({
+                                "key": f"set:{name}:{len(pending_actions)}",
+                                "kind": "set_value",
+                                "selector": str(selector),
+                                "value": str(value),
+                            })
                             del fields[str(name)]
                         else:
                             print(f"{CROSS}{RED} No form data found for {BOLD}{name}{NORMAL}")

--- a/middleman.py
+++ b/middleman.py
@@ -304,6 +304,103 @@ async def page_batch_extract(page: zd.Tab, queries: list[dict[str, object]]) -> 
     return None
 
 
+async def page_batch_actions(page: zd.Tab, actions: list[dict[str, str]]) -> dict[str, bool] | None:
+    if len(actions) == 0:
+        return {}
+
+    payload = json.dumps(actions)
+    js_code = f"""
+    (() => {{
+        const actions = {payload};
+        const output = {{}};
+
+        function findCss(selector, doc) {{
+            try {{
+                const direct = doc.querySelector(selector);
+                if (direct) return direct;
+            }} catch (error) {{
+                return null;
+            }}
+
+            const iframes = doc.querySelectorAll("iframe");
+            for (const iframe of iframes) {{
+                try {{
+                    const childDoc = iframe.contentDocument || iframe.contentWindow.document;
+                    const nested = findCss(selector, childDoc);
+                    if (nested) return nested;
+                }} catch (error) {{
+                    // Cross-origin iframe.
+                }}
+            }}
+            return null;
+        }}
+
+        for (const action of actions) {{
+            const key = action?.key;
+            const kind = action?.kind;
+            const selector = action?.selector;
+            if (typeof key !== "string" || key.length === 0) {{
+                continue;
+            }}
+            if (typeof selector !== "string" || selector.length === 0) {{
+                output[key] = false;
+                continue;
+            }}
+
+            let element = null;
+            if (selector.startsWith("//")) {{
+                try {{
+                    element = document.evaluate(
+                        selector,
+                        document,
+                        null,
+                        XPathResult.FIRST_ORDERED_NODE_TYPE,
+                        null
+                    ).singleNodeValue;
+                }} catch (error) {{
+                    element = null;
+                }}
+            }} else {{
+                element = findCss(selector, document);
+            }}
+
+            if (!element) {{
+                output[key] = false;
+                continue;
+            }}
+
+            try {{
+                if (kind === "click") {{
+                    element.click();
+                    output[key] = true;
+                }} else if (kind === "set_value") {{
+                    const value = typeof action?.value === "string" ? action.value : "";
+                    element.value = value;
+                    element.dispatchEvent(new Event("input", {{ bubbles: true }}));
+                    element.dispatchEvent(new Event("change", {{ bubbles: true }}));
+                    output[key] = true;
+                }} else {{
+                    output[key] = false;
+                }}
+            }} catch (error) {{
+                output[key] = false;
+            }}
+        }}
+
+        return output;
+    }})()
+    """
+
+    try:
+        result = await page.evaluate(js_code)
+        if isinstance(result, dict):
+            return {str(k): bool(v) for k, v in result.items()}
+    except Exception as error:
+        if MIDDLEMAN_DEBUG:
+            print(f"{YELLOW}Batch actions failed: {error}{NORMAL}")
+    return None
+
+
 async def distill(hostname: str | None, page, patterns: list[Pattern]) -> Match | None:
     result: list[Match] = []
 
@@ -967,26 +1064,35 @@ async def link(id: str, request: Request):
                 return JSONResponse(converted)
             return HTMLResponse(render(str(document.find("body")), {"title": title, "action": action}))
 
+
+
         if fields.get("button"):
             button = document.find("button", value=str(fields.get("button")))
             if button and isinstance(button, Tag):
                 button_selector, _ = get_selector(str(button.get("gg-match")))
-                button_element = await page_query_selector(page, str(button_selector))
-                if button_element:
-                    print(f"{CYAN}{ARROW} Clicking button {BOLD}{button_selector}{NORMAL}")
-                    await button_element.click()
+                batch_click = await page_batch_actions(
+                    page,
+                    [{"key": "button", "kind": "click", "selector": str(button_selector)}],
+                )
+                if batch_click and batch_click.get("button", False):
+                    print(f"{CYAN}{ARROW} Clicking button {BOLD}{button_selector}{NORMAL} (batch)")
+                else:
+                    button_element = await page_query_selector(page, str(button_selector))
+                    if button_element:
+                        print(f"{CYAN}{ARROW} Clicking button {BOLD}{button_selector}{NORMAL}")
+                        await button_element.click()
                 continue
 
         names: list[str] = []
         inputs = document.find_all("input")
+        pending_actions: list[dict[str, str]] = []
 
         for input in inputs:
             if isinstance(input, Tag):
                 selector, _ = get_selector(str(input.get("gg-match")))
-                element = await page_query_selector(page, selector)
                 name = input.get("name")
 
-                if selector and element:
+                if selector:
                     if input.get("type") == "checkbox":
                         if not name:
                             print(f"{CROSS}{RED} No name for the checkbox {NORMAL}{selector}")
@@ -996,7 +1102,13 @@ async def link(id: str, request: Request):
                         names.append(str(name))
                         print(f"{CYAN}{ARROW} Status of checkbox {BOLD}{name}={checked}{NORMAL}")
                         if checked:
-                            await element.click()
+                            pending_actions.append(
+                                {
+                                    "key": f"checkbox:{name}:{len(pending_actions)}",
+                                    "kind": "click",
+                                    "selector": str(selector),
+                                }
+                            )
                     elif input.get("type") == "radio":
                         value = fields.get(str(name)) if name else None
                         if not value or len(str(value)) == 0:
@@ -1009,13 +1121,16 @@ async def link(id: str, request: Request):
                         print(f"{CYAN}{ARROW} Handling radio button group {BOLD}{name}{NORMAL}")
                         print(f"{CYAN}{ARROW} Using form data {BOLD}{name}={value}{NORMAL}")
                         radio_selector, _ = get_selector(str(radio.get("gg-match")))
-                        radio_element = await page_query_selector(page, str(radio_selector))
-                        if radio_element:
-                            await radio_element.click()
+                        pending_actions.append(
+                            {
+                                "key": f"radio:{value}:{len(pending_actions)}",
+                                "kind": "click",
+                                "selector": str(radio_selector),
+                            }
+                        )
                         radio["checked"] = "checked"
                         current["distilled"] = str(document)
                         names.append(str(input.get("id")) if input.get("id") else "radio")
-                        await asyncio.sleep(0.25)
                     elif name:
                         value = fields.get(str(name))
                         if value and len(str(value)) > 0:
@@ -1023,11 +1138,42 @@ async def link(id: str, request: Request):
                             names.append(str(name))
                             input["value"] = str(value)
                             current["distilled"] = str(document)
-                            await element.type_text(str(value))
+                            pending_actions.append(
+                                {
+                                    "key": f"set:{name}:{len(pending_actions)}",
+                                    "kind": "set_value",
+                                    "selector": str(selector),
+                                    "value": str(value),
+                                }
+                            )
                             del fields[str(name)]
-                            await asyncio.sleep(0.25)
                         else:
                             print(f"{CROSS}{RED} No form data found for {BOLD}{name}{NORMAL}")
+
+        if len(pending_actions) > 0:
+            action_results = await page_batch_actions(page, pending_actions)
+            results = action_results if isinstance(action_results, dict) else {}
+
+            # Fallback for failed/unexecuted actions to preserve behavior.
+            for action in pending_actions:
+                key = action.get("key")
+                kind = action.get("kind")
+                selector = action.get("selector")
+                if not isinstance(key, str) or not isinstance(kind, str) or not isinstance(selector, str):
+                    continue
+                if results.get(key, False):
+                    continue
+
+                element = await page_query_selector(page, selector)
+                if not element:
+                    continue
+                if kind == "click":
+                    await element.click()
+                elif kind == "set_value":
+                    value = action.get("value")
+                    await element.type_text(value if isinstance(value, str) else "")
+
+            await asyncio.sleep(0.25)
 
         await autoclick(page, distilled, "[gg-autoclick]:not(button)")
 

--- a/middleman.py
+++ b/middleman.py
@@ -202,6 +202,108 @@ class Match:
     distilled: str
 
 
+async def page_batch_extract(page: zd.Tab, queries: list[dict[str, object]]) -> dict[str, dict[str, object]] | None:
+    if len(queries) == 0:
+        return {}
+
+    payload = json.dumps(queries)
+    js_code = f"""
+    (() => {{
+        const queries = {payload};
+        const output = {{}};
+
+        function findCss(selector, doc) {{
+            try {{
+                const direct = doc.querySelector(selector);
+                if (direct) return direct;
+            }} catch (error) {{
+                return null;
+            }}
+
+            const iframes = doc.querySelectorAll("iframe");
+            for (const iframe of iframes) {{
+                try {{
+                    const childDoc = iframe.contentDocument || iframe.contentWindow.document;
+                    const nested = findCss(selector, childDoc);
+                    if (nested) return nested;
+                }} catch (error) {{
+                    // Cross-origin iframe.
+                }}
+            }}
+
+            return null;
+        }}
+
+        for (const query of queries) {{
+            const selector = query?.selector;
+            const queryKey = query?.query_key;
+            if (typeof selector !== "string" || selector.length === 0) {{
+                continue;
+            }}
+            if (typeof queryKey !== "string" || queryKey.length === 0) {{
+                continue;
+            }}
+
+            let element = null;
+
+            if (selector.startsWith("//")) {{
+                try {{
+                    element = document.evaluate(
+                        selector,
+                        document,
+                        null,
+                        XPathResult.FIRST_ORDERED_NODE_TYPE,
+                        null
+                    ).singleNodeValue;
+                }} catch (error) {{
+                    element = null;
+                }}
+            }} else {{
+                element = findCss(selector, document);
+            }}
+
+            if (!element) {{
+                output[queryKey] = {{ found: false }};
+                continue;
+            }}
+
+            const tag = String(element.tagName || "").toLowerCase();
+            const item = {{ found: true, tag }};
+
+            if (query?.wants_html) {{
+                item.html = element.innerHTML || "";
+            }}
+            if (query?.wants_text) {{
+                item.text = element.innerText || "";
+            }}
+            if (query?.wants_value && ["input", "textarea", "select"].includes(tag)) {{
+                const value = element.value;
+                if (typeof value === "string") {{
+                    item.value = value;
+                }} else if (value == null) {{
+                    item.value = "";
+                }} else {{
+                    item.value = String(value);
+                }}
+            }}
+
+            output[queryKey] = item;
+        }}
+
+        return output;
+    }})()
+    """
+
+    try:
+        result = await page.evaluate(js_code)
+        if isinstance(result, dict):
+            return result
+    except Exception as error:
+        if MIDDLEMAN_DEBUG:
+            print(f"{YELLOW}Batch extract failed: {error}{NORMAL}")
+    return None
+
+
 async def distill(hostname: str | None, page, patterns: list[Pattern]) -> Match | None:
     result: list[Match] = []
 
@@ -226,9 +328,9 @@ async def distill(hostname: str | None, page, patterns: list[Pattern]) -> Match 
 
         print(f"Checking {name} with priority {priority}")
 
-        found = True
-        match_count = 0
         targets = pattern.find_all(attrs={"gg-match": True}) + pattern.find_all(attrs={"gg-match-html": True})
+        target_specs: list[dict[str, object]] = []
+        batch_queries: list[dict[str, object]] = []
 
         for target in targets:
             if not isinstance(target, Tag):
@@ -236,36 +338,76 @@ async def distill(hostname: str | None, page, patterns: list[Pattern]) -> Match 
 
             if MIDDLEMAN_DEBUG:
                 print(f"Checking target = {target}")
-            html = target.get("gg-match-html")
-            selector, _ = get_selector(str(html if html else target.get("gg-match")))
+
+            html_attr = target.get("gg-match-html")
+            selector, _ = get_selector(str(html_attr if html_attr else target.get("gg-match")))
             if not selector or not isinstance(selector, str):
                 continue
 
-            print(f"Find selector {selector}")
-            source = await page_query_selector(page, selector)
-            if source:
-                print(f"{GREEN}Selector {selector} is source {source}{NORMAL}")
+            is_html = html_attr is not None
+            query_key = str(len(target_specs))
+            optional = target.get("gg-optional") is not None
+
+            target_specs.append({
+                "target": target,
+                "selector": selector,
+                "html": is_html,
+                "optional": optional,
+                "query_key": query_key,
+            })
+            batch_queries.append({
+                "query_key": query_key,
+                "selector": selector,
+                "wants_html": is_html,
+                "wants_text": not is_html,
+                "wants_value": not is_html,
+            })
+
+        found = True
+        match_count = 0
+
+        batch_results = await page_batch_extract(page, batch_queries)
+        safe_results = batch_results if isinstance(batch_results, dict) else {}
+
+        for spec in target_specs:
+            target = spec.get("target")
+            selector = spec.get("selector")
+            query_key = spec.get("query_key")
+            html = bool(spec.get("html"))
+            optional = bool(spec.get("optional"))
+
+            if not isinstance(target, Tag):
+                continue
+            if not isinstance(selector, str) or not isinstance(query_key, str):
+                continue
+
+            source = safe_results.get(query_key, {})
+            source_found = bool(source.get("found")) if isinstance(source, dict) else False
+
+            if source_found:
                 if html:
                     target.clear()
-                    fragment = BeautifulSoup("<div>" + await source.inner_html() + "</div>", "html.parser")
+                    html_content = source.get("html", "") if isinstance(source, dict) else ""
+                    fragment = BeautifulSoup("<div>" + str(html_content) + "</div>", "html.parser")
                     if fragment.div:
                         for child in list(fragment.div.children):
                             child.extract()
                             target.append(child)
                 else:
-                    raw_text = await source.inner_text()
-                    if raw_text:
+                    raw_text = source.get("text") if isinstance(source, dict) else None
+                    if isinstance(raw_text, str) and raw_text:
                         target.string = raw_text.strip()
-                    if source.tag in ["input", "textarea", "select"]:
-                        target["value"] = source.element.value or ""
+                    tag = str(source.get("tag", "")).lower() if isinstance(source, dict) else ""
+                    if tag in ["input", "textarea", "select"]:
+                        value = source.get("value", "") if isinstance(source, dict) else ""
+                        target["value"] = value if isinstance(value, str) else ""
                 match_count += 1
-            else:
-                print(f"{RED}Selector {selector} has no match{NORMAL}")
-                optional = target.get("gg-optional") is not None
-                if MIDDLEMAN_DEBUG and optional:
-                    print(f"{GRAY}Optional {selector} has no match{NORMAL}")
-                if not optional:
-                    found = False
+                continue
+
+            if MIDDLEMAN_DEBUG and optional:
+                print(f"{GRAY}Optional {selector} has no match{NORMAL}")
+            if not optional:
+                found = False
 
         if found and match_count > 0:
             distilled = str(pattern)


### PR DESCRIPTION
## Summary

This PR improves the performance of the distill-related actions by batching the actions (fill & click). The updated implementation significantly reduces latency, especially for previously slow steps.

Benchmark results show consistent and reproducible improvements across multiple runs.

Test by doing E2E flow of Goodreads (From open to get result, 5 distill called). With local middleman & lambda chromefleet.

---

## Benchmark Comparison

### Action Latency (per run)

- **Before:** One slow action (fill text) consistently took ~28.4–28.6s  
- **After:** Reduced to ~0.47–0.62s  
- **Impact:** ~45–60x faster for the slowest action

---

### End-to-End Test Time (per test)

- **Before:** ~53,583 ms average  
- **After:** ~26,625 ms average  
- **Impact:** ~2.01x faster (`-~26,958 ms`)

---

### Per-Test Totals

| Test | Before (ms) | After (ms) | Change |
|---|---:|---:|---:|
| 1 | 53,583 | 25,452 | 2.10x faster |
| 2 | 53,827 | 27,240 | 1.98x faster |
| 3 | 53,790 | 27,184 | 1.98x faster |

